### PR TITLE
Bring your own config support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
 CHART_PATH = helm/wireguard
+OVERRIDE_PATH ?= ci/default.yaml
 
 lint:
-	helm lint $(CHART_PATH)
+	helm lint $(CHART_PATH) -f $(OVERRIDE_PATH)
 
 template:
-	helm template --debug  --disable-openapi-validation $(CHART_PATH)
+	helm template --debug  --disable-openapi-validation $(CHART_PATH) -f $(OVERRIDE_PATH)
+
+docs-update:
+	docker run --rm --volume "$$PWD:/helm-docs" jnorwood/helm-docs:latest

--- a/ci/test-with-byoc.yaml
+++ b/ci/test-with-byoc.yaml
@@ -1,0 +1,2 @@
+configSecretName: my-super-duper-config-secret
+configSecretProperty: not-wg0.conf

--- a/ci/test-with-byos.yaml
+++ b/ci/test-with-byos.yaml
@@ -1,0 +1,1 @@
+secretName: my-super-duper-secret

--- a/ci/test-with-disabled-config-mgmt.yaml
+++ b/ci/test-with-disabled-config-mgmt.yaml
@@ -1,0 +1,1 @@
+disableConfigManagement: true

--- a/ci/test-with-disabled-secret-mgmt.yaml
+++ b/ci/test-with-disabled-secret-mgmt.yaml
@@ -1,0 +1,1 @@
+disablePrivateKeyManagement: true

--- a/ci/test-with-volumes.yaml
+++ b/ci/test-with-volumes.yaml
@@ -1,0 +1,7 @@
+volumes:
+  - name: vol
+    hostPath:
+      path: /any/path/it/will/be/replaced
+volumeMounts:
+  - name: vol
+    mountPath: /mount-in-container

--- a/helm/wireguard/Chart.yaml
+++ b/helm/wireguard/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wireguard
 description: A Helm chart for managing a wireguard vpn in kubernetes
 type: application
-version: 0.9.0
+version: 0.10.0
 appVersion: "0.0.0"
 maintainers:
   - name: bryopsida

--- a/helm/wireguard/README.md
+++ b/helm/wireguard/README.md
@@ -1,6 +1,6 @@
 # wireguard
 
-![Version: 0.9.0](https://img.shields.io/badge/Version-0.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
+![Version: 0.10.0](https://img.shields.io/badge/Version-0.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
 
 A Helm chart for managing a wireguard vpn in kubernetes
 
@@ -18,6 +18,8 @@ A Helm chart for managing a wireguard vpn in kubernetes
 | autoscaling.maxReplicas | int | `10` |  |
 | autoscaling.minReplicas | int | `3` |  |
 | autoscaling.targetCPUUtilizationPercentage | int | `75` |  |
+| configSecretName | string | `nil` | If provided, this secret will be used instead of the config created from the helm value scope |
+| configSecretProperty | string | `"wg0.conf"` | The property/key on the secret holding the wireguard configuration file |
 | deploymentStrategy.rollingUpdate.maxSurge | int | `1` |  |
 | deploymentStrategy.rollingUpdate.maxUnavailable | int | `0` |  |
 | deploymentStrategy.type | string | `"RollingUpdate"` |  |

--- a/helm/wireguard/README.md
+++ b/helm/wireguard/README.md
@@ -47,6 +47,8 @@ A Helm chart for managing a wireguard vpn in kubernetes
 | service.enabled | bool | `true` | Whether the service will be created or not |
 | service.port | int | `51280` | Service port, default is 51280 UDP |
 | service.type | string | `"LoadBalancer"` | Service type, to keep internal to cluster use ClusterIP |
+| volumeMounts | object | `{}` | Passthrough pod volume mounts |
+| volumes | object | `{}` | Passthrough pod volumes |
 | wireguard.clients | list | `[]` | A collection of clients that will be added to wg0.conf, accepts objects with keys PublicKey and AllowedIPs, stored in secret |
 | wireguard.serverAddress | string | `"10.34.0.1/24"` | Address of the VPN server |
 | wireguard.serverCidr | string | `"10.34.0.0/24"` |  |

--- a/helm/wireguard/README.md
+++ b/helm/wireguard/README.md
@@ -23,6 +23,8 @@ A Helm chart for managing a wireguard vpn in kubernetes
 | deploymentStrategy.rollingUpdate.maxSurge | int | `1` |  |
 | deploymentStrategy.rollingUpdate.maxUnavailable | int | `0` |  |
 | deploymentStrategy.type | string | `"RollingUpdate"` |  |
+| disableConfigManagement | bool | `false` | Disable creation and any mount of the wireguard confifugration file, this assumes another mechanism is provided/used to manage a configuration file |
+| disablePrivateKeyManagement | bool | `false` | Disable creation and any mounting of a private key, this assumes another mechanism is provided/used at the container level to fetch the private key |
 | disruptionBudget.enabled | bool | `true` |  |
 | disruptionBudget.minAvailable | int | `2` |  |
 | extraEnv | object | `{}` | Provide additional environment variables to the wireguard container |

--- a/helm/wireguard/templates/config.yaml
+++ b/helm/wireguard/templates/config.yaml
@@ -17,9 +17,11 @@ PresharedKey = {{ .PresharedKey }}
 {{- end }}
 # End Clients
 {{- end -}}
+{{- if not .Values.configSecretName }}
 kind: Secret
 apiVersion: v1
 metadata:
   name: "{{ .Release.Name }}-wg-config"
 data:
   wg0.conf: {{ include "wg-config-template" . | b64enc }}
+{{- end }}

--- a/helm/wireguard/templates/config.yaml
+++ b/helm/wireguard/templates/config.yaml
@@ -17,7 +17,7 @@ PresharedKey = {{ .PresharedKey }}
 {{- end }}
 # End Clients
 {{- end -}}
-{{- if not .Values.configSecretName }}
+{{- if and (not .Values.configSecretName) (not .Values.disableConfigManagement) }}
 kind: Secret
 apiVersion: v1
 metadata:

--- a/helm/wireguard/templates/deployment.yaml
+++ b/helm/wireguard/templates/deployment.yaml
@@ -131,18 +131,26 @@ spec:
           volumeMounts:
           - name: run
             mountPath: /run
+          {{- if not .Values.disableConfigManagement }}
           - name: config
             mountPath: /etc/wireguard/wg0.conf
             subPath: {{ .Values.configSecretProperty | quote }}
+          {{- end }}
+          {{- if not .Values.disablePrivateKeyManagement }}
           - name: privatekey
             mountPath: /etc/wireguard/privatekey
             subPath: privatekey
+          {{- end }}
       volumes:
       - name: run
         emptyDir: {}
+      {{- if not .Values.disableConfigManagement }}
       - name: config
         secret:
           secretName: "{{ coalesce .Values.configSecretName (printf "%s-wg-config" .Release.Name) }}"
+      {{- end }}
+      {{- if not .Values.disablePrivateKeyManagement }}
       - name: privatekey
         secret:
           secretName: "{{ coalesce .Values.secretName (printf "%s-wg-generated" .Release.Name) }}"
+      {{- end }}

--- a/helm/wireguard/templates/deployment.yaml
+++ b/helm/wireguard/templates/deployment.yaml
@@ -56,7 +56,9 @@ spec:
   template:
     metadata:
       annotations:
+        {{- if not .Values.configSecretName }}
         checksum/config: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
+        {{- end }}
         {{- if .Values.podAnnotations }}
         {{- range $key, $value := .Values.podAnnotations  }}
         {{ $key }}: {{ $value | quote }}
@@ -110,7 +112,7 @@ spec:
             name: wireguard
           env:
           - name: LOG_LEVEL
-            value: info
+            value: {{ default "info" .Values.logLevel }}
           {{- range $key, $value := .Values.extraEnv }}
           - name: {{ $key }}
             value: {{ $value | quote }}
@@ -131,7 +133,7 @@ spec:
             mountPath: /run
           - name: config
             mountPath: /etc/wireguard/wg0.conf
-            subPath: wg0.conf
+            subPath: {{ .Values.configSecretProperty | quote }}
           - name: privatekey
             mountPath: /etc/wireguard/privatekey
             subPath: privatekey
@@ -140,7 +142,7 @@ spec:
         emptyDir: {}
       - name: config
         secret:
-          secretName: "{{ .Release.Name }}-wg-config"
+          secretName: "{{ coalesce .Values.configSecretName (printf "%s-wg-config" .Release.Name) }}"
       - name: privatekey
         secret:
-          secretName: {{ coalesce .Values.secretName (printf "%s-wg-generated" .Release.Name) }}
+          secretName: "{{ coalesce .Values.secretName (printf "%s-wg-generated" .Release.Name) }}"

--- a/helm/wireguard/templates/deployment.yaml
+++ b/helm/wireguard/templates/deployment.yaml
@@ -141,6 +141,9 @@ spec:
             mountPath: /etc/wireguard/privatekey
             subPath: privatekey
           {{- end }}
+          {{- if .Values.volumeMounts }}
+            {{- .Values.volumeMounts | toYaml | nindent 10 }}
+          {{- end }}
       volumes:
       - name: run
         emptyDir: {}
@@ -153,4 +156,7 @@ spec:
       - name: privatekey
         secret:
           secretName: "{{ coalesce .Values.secretName (printf "%s-wg-generated" .Release.Name) }}"
+      {{- end }}
+      {{- if .Values.volumes }}
+        {{- .Values.volumes | toYaml | nindent 6 }}
       {{- end }}

--- a/helm/wireguard/templates/privatekey-gen-job.yaml
+++ b/helm/wireguard/templates/privatekey-gen-job.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.secretName }}
+{{- if and (not .Values.secretName) (not .Values.disablePrivateKeyManagement)  }}
 {{- /* Only needed if a secret isn't provided */}}
 
 {{- /* Create role for the hook job so it can create a secret */}}

--- a/helm/wireguard/values.yaml
+++ b/helm/wireguard/values.yaml
@@ -58,3 +58,7 @@ configSecretProperty: wg0.conf
 disablePrivateKeyManagement: false
 # -- Disable creation and any mount of the wireguard confifugration file, this assumes another mechanism is provided/used to manage a configuration file
 disableConfigManagement: false
+# -- Passthrough pod volumes
+volumes: {}
+# -- Passthrough pod volume mounts
+volumeMounts: {}

--- a/helm/wireguard/values.yaml
+++ b/helm/wireguard/values.yaml
@@ -54,3 +54,7 @@ extraEnv: {}
 configSecretName: ~
 # -- The property/key on the secret holding the wireguard configuration file
 configSecretProperty: wg0.conf
+# -- Disable creation and any mounting of a private key, this assumes another mechanism is provided/used at the container level to fetch the private key
+disablePrivateKeyManagement: false
+# -- Disable creation and any mount of the wireguard confifugration file, this assumes another mechanism is provided/used to manage a configuration file
+disableConfigManagement: false

--- a/helm/wireguard/values.yaml
+++ b/helm/wireguard/values.yaml
@@ -50,3 +50,7 @@ autoscaling:
 # -- Provide additional environment variables to the wireguard container
 extraEnv: {}
 #  TEST_ENV_VAR: test-value
+# -- If provided, this secret will be used instead of the config created from the helm value scope
+configSecretName: ~
+# -- The property/key on the secret holding the wireguard configuration file
+configSecretProperty: wg0.conf


### PR DESCRIPTION
What
---
Adds support for opting out of managing the wireguard configuration via helm values when a value for `configSecretName` is provided. In this case by default it will use the `wg0.conf` property of the referenced secret name in `configSecretName`,  if the configuration file is on a different property `configSecretProperty` can be used to pull from a different property key.

New Values
---
```
# -- If provided, this secret will be used instead of the config created from the helm value scope
configSecretName: ~
# -- The property/key on the secret holding the wireguard configuration file
configSecretProperty: wg0.conf
# -- Disable creation and any mounting of a private key, this assumes another mechanism is provided/used at the container level to fetch the private key
disablePrivateKeyManagement: false
# -- Disable creation and any mount of the wireguard confifugration file, this assumes another mechanism is provided/used to manage a configuration file
disableConfigManagement: false
# -- Passthrough pod volumes
volumes: {}
# -- Passthrough pod volume mounts
volumeMounts: {}
```