### PR TITLE
Add more extension points

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,23 @@
 CHART_PATH = helm/wireguard
 OVERRIDE_PATH ?= ci/default.yaml
+TEMPLATE_ARGS ?= '--disable-openapi-validation'
+HELM_NAMESPACE ?= wireguard-test
+HELM_RELEASE_NAME ?= wireguard-test
 
 lint:
 	helm lint $(CHART_PATH) -f $(OVERRIDE_PATH)
 
 template:
-	helm template --debug  --disable-openapi-validation $(CHART_PATH) -f $(OVERRIDE_PATH)
+	helm template --debug  $(TEMPLATE_ARGS) $(CHART_PATH) -f $(OVERRIDE_PATH)
+	
+deploy:
+	helm --namespace $(HELM_NAMESPACE) upgrade --install $(HELM_RELEASE_NAME) ./helm/wireguard/ -f $(OVERRIDE_PATH) $(HELM_EXTRA_ARGS)
+
+clean-secret:
+	kubectl --namespace $(HELM_NAMESPACE) delete secret $(HELM_RELEASE_NAME)-wg-generated
+
+clean:
+	helm --namespace $(HELM_NAMESPACE) del $(HELM_RELEASE_NAME)
 
 docs-update:
 	docker run --rm --volume "$$PWD:/helm-docs" jnorwood/helm-docs:latest

--- a/ci/test-with-clusterip.yaml
+++ b/ci/test-with-clusterip.yaml
@@ -1,0 +1,2 @@
+service:
+  type: ClusterIP

--- a/ci/test-with-custom-keygen-script.yaml
+++ b/ci/test-with-custom-keygen-script.yaml
@@ -1,0 +1,10 @@
+keygenJob:
+  extraScripts:
+    test.sh: |
+      #!/usr/bin/env sh
+      echo "Hello from custom script, EXTRA_NAMESPACE=$EXTRA_NAMESPACE"
+      /job/entry-point.sh
+  extraEnv:
+    EXTRA_NAMESPACE: "{{ .Release.Namespace }}"
+  command:
+    - "/job/test.sh"

--- a/ci/test-with-dns-config.yaml
+++ b/ci/test-with-dns-config.yaml
@@ -1,0 +1,11 @@
+dnsPolicy: None
+dnsConfig:
+  nameservers:
+    - 192.0.2.1 # this is an example
+  searches:
+    - ns1.svc.cluster-domain.example
+    - my.dns.search.suffix
+  options:
+    - name: ndots
+      value: "2"
+    - name: edns0

--- a/ci/test-with-extra-secret-env.yaml
+++ b/ci/test-with-extra-secret-env.yaml
@@ -1,0 +1,9 @@
+keygenJob:
+  extraEnvSecrets:
+    TEST_1:
+      secretName: SUPER_DUPER_SECRET
+      secretPropertyName: password
+extraEnvSecrets:
+  TEST_2:
+    secretName: SUPER_DUPER_SECRET
+    secretPropertyName: password

--- a/ci/test-with-nodeport.yaml
+++ b/ci/test-with-nodeport.yaml
@@ -1,0 +1,2 @@
+service:
+  type: NodePort

--- a/ci/test-with-runtimeclass.yaml
+++ b/ci/test-with-runtimeclass.yaml
@@ -1,0 +1,1 @@
+runtimeClassName: 'runc'

--- a/ci/test-with-seccomp.yaml
+++ b/ci/test-with-seccomp.yaml
@@ -1,0 +1,3 @@
+securityContext:
+  seccompProfile:
+    type: RuntimeDefault

--- a/helm/wireguard/Chart.yaml
+++ b/helm/wireguard/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wireguard
 description: A Helm chart for managing a wireguard vpn in kubernetes
 type: application
-version: 0.12.0
+version: 0.13.0
 appVersion: "0.0.0"
 maintainers:
   - name: bryopsida

--- a/helm/wireguard/README.md
+++ b/helm/wireguard/README.md
@@ -31,12 +31,15 @@ A Helm chart for managing a wireguard vpn in kubernetes
 | image.pullPolicy | string | `"Always"` |  |
 | image.repository | string | `"ghcr.io/bryopsida/wireguard"` |  |
 | image.tag | string | `"main"` |  |
+| keygenJob.command | list | `["/job/entry-point.sh"]` | Specify the script to run to generate the private key |
 | keygenJob.containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
 | keygenJob.containerSecurityContext.privileged | bool | `false` |  |
 | keygenJob.containerSecurityContext.readOnlyRootFilesystem | bool | `true` |  |
 | keygenJob.containerSecurityContext.runAsGroup | int | `1000` |  |
 | keygenJob.containerSecurityContext.runAsNonRoot | bool | `true` |  |
 | keygenJob.containerSecurityContext.runAsUser | int | `1000` |  |
+| keygenJob.extraEnv | object | `{}` | Add additional environment variables to the key generation job, supports helm templating |
+| keygenJob.extraScripts | object | `{}` | Inject additional scripts into the key generation job |
 | keygenJob.image.pullPolicy | string | `"Always"` |  |
 | keygenJob.image.repository | string | `"ghcr.io/curium-rocks/wg-kubectl"` |  |
 | keygenJob.image.tag | string | `"latest"` |  |

--- a/helm/wireguard/README.md
+++ b/helm/wireguard/README.md
@@ -1,6 +1,6 @@
 # wireguard
 
-![Version: 0.12.0](https://img.shields.io/badge/Version-0.12.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
+![Version: 0.13.0](https://img.shields.io/badge/Version-0.13.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
 
 A Helm chart for managing a wireguard vpn in kubernetes
 
@@ -31,6 +31,18 @@ A Helm chart for managing a wireguard vpn in kubernetes
 | image.pullPolicy | string | `"Always"` |  |
 | image.repository | string | `"ghcr.io/bryopsida/wireguard"` |  |
 | image.tag | string | `"main"` |  |
+| keygenJob.containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
+| keygenJob.containerSecurityContext.privileged | bool | `false` |  |
+| keygenJob.containerSecurityContext.readOnlyRootFilesystem | bool | `true` |  |
+| keygenJob.containerSecurityContext.runAsGroup | int | `1000` |  |
+| keygenJob.containerSecurityContext.runAsNonRoot | bool | `true` |  |
+| keygenJob.containerSecurityContext.runAsUser | int | `1000` |  |
+| keygenJob.image.pullPolicy | string | `"Always"` |  |
+| keygenJob.image.repository | string | `"ghcr.io/curium-rocks/wg-kubectl"` |  |
+| keygenJob.image.tag | string | `"latest"` |  |
+| keygenJob.podSecurityContext.fsGroup | int | `1000` |  |
+| keygenJob.podSecurityContext.fsGroupChangePolicy | string | `"Always"` |  |
+| keygenJob.podSecurityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
 | labels | object | `{}` |  |
 | podAnnotations | object | `{}` |  |
 | replicaCount | int | `3` |  |
@@ -38,6 +50,7 @@ A Helm chart for managing a wireguard vpn in kubernetes
 | resources.limits.memory | string | `"256Mi"` |  |
 | resources.requests.cpu | string | `"100m"` |  |
 | resources.requests.memory | string | `"256Mi"` |  |
+| runtimeClassName | string | `nil` | Override the default runtime class of the container, if not provided `runc` will most likely be used |
 | secretName | string | `nil` | Name of a secret with a wireguard private key on key privatekey, if not provided on first install a hook generates one. |
 | securityContext.allowPrivilegeEscalation | bool | `true` |  |
 | securityContext.privileged | bool | `false` |  |

--- a/helm/wireguard/templates/_helpers.tpl
+++ b/helm/wireguard/templates/_helpers.tpl
@@ -49,3 +49,18 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
+
+
+{{/* Seccomp profile partial */}}
+{{- define "wireguard.seccompProfile" -}}
+{{- if .Values.securityContext.seccompProfile }}
+seccompProfile: {{ .Values.securityContext.seccompProfile | toYaml | nindent 2}}
+{{- end }}
+{{- end -}}
+
+{{/* Runtime Class partial */}}
+{{- define "wireguard.runtimeClass" }}
+{{- if .Values.runtimeClassName }}
+runtimeClassName: "{{ .Values.runtimeClassName }}"
+{{- end }}
+{{- end }}

--- a/helm/wireguard/templates/deployment.yaml
+++ b/helm/wireguard/templates/deployment.yaml
@@ -7,6 +7,7 @@ exec:
 {{- end -}}
 
 {{- define "core.securitycontext" -}}
+{{ include "wireguard.seccompProfile" . }}
 capabilities:
   drop:
     - ALL
@@ -73,16 +74,28 @@ spec:
         {{- end }}
         {{- end }}
     spec:
+      {{- include "wireguard.runtimeClass" . | indent 6 }}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy }}
+      {{- end }}
+      {{- if .Values.dnsConfig }}
+      dnsConfig: {{ .Values.dnsConfig | toYaml | nindent  8 }}
+      {{- end }}
       serviceAccountName: {{ .Release.Name }}-sa
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: kubernetes.io/hostname
           whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            app: "{{ .Release.Name }}-wireguard"
+          matchLabelKeys:
+            - pod-template-hash
       automountServiceAccountToken: false
       securityContext:
         fsGroup: {{ .Values.securityContext.runAsUser | default 1000 }}
         fsGroupChangePolicy: "OnRootMismatch"
         runAsNonRoot: {{ .Values.securityContext.runAsNonRoot | default true }}
+        {{- include "wireguard.seccompProfile" . | indent 8 }}
       {{- if .Values.image.pullSecret }}
       imagePullSecrets:
         - name: "{{ .Values.image.pullSecret }}"

--- a/helm/wireguard/templates/deployment.yaml
+++ b/helm/wireguard/templates/deployment.yaml
@@ -129,7 +129,14 @@ spec:
             value: {{ default "info" .Values.logLevel }}
           {{- range $key, $value := .Values.extraEnv }}
           - name: {{ $key }}
-            value: {{ $value | quote }}
+            value: {{ (tpl $value $) | quote }}
+          {{- end }}
+          {{- range $key, $value := .Values.extraEnvSecrets }}
+          - name: {{ $key }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ tpl $value.secretName $ }}
+                key: {{ tpl $value.secretPropertyName $ }}
           {{- end }}
           securityContext: {{ include "wg.securitycontext" . | nindent 12 }}
           resources: {{ .Values.resources | toYaml | nindent 12 }}

--- a/helm/wireguard/templates/deployment.yaml
+++ b/helm/wireguard/templates/deployment.yaml
@@ -89,8 +89,10 @@ spec:
           labelSelector:
             matchLabels:
               app: "{{ .Release.Name }}-wireguard"
+          {{- if semverCompare ">=1.27-0" .Capabilities.KubeVersion.GitVersion }}
           matchLabelKeys:
             - pod-template-hash
+          {{- end }}
       automountServiceAccountToken: false
       securityContext:
         fsGroup: {{ .Values.securityContext.runAsUser | default 1000 }}

--- a/helm/wireguard/templates/deployment.yaml
+++ b/helm/wireguard/templates/deployment.yaml
@@ -87,7 +87,8 @@ spec:
           topologyKey: kubernetes.io/hostname
           whenUnsatisfiable: ScheduleAnyway
           labelSelector:
-            app: "{{ .Release.Name }}-wireguard"
+            matchLabels:
+              app: "{{ .Release.Name }}-wireguard"
           matchLabelKeys:
             - pod-template-hash
       automountServiceAccountToken: false

--- a/helm/wireguard/templates/privatekey-gen-job.yaml
+++ b/helm/wireguard/templates/privatekey-gen-job.yaml
@@ -72,7 +72,13 @@ metadata:
     "helm.sh/resource-policy": delete
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 data:
-{{ (.Files.Glob "scripts/*").AsConfig | indent 2 }}  
+{{ (.Files.Glob "scripts/*").AsConfig | indent 2 }}
+{{- if .Values.keygenJob.extraScripts }}
+{{- range $key, $value := .Values.keygenJob.extraScripts }}
+  {{- $key | nindent 2 }}: |
+    {{- $value | nindent 4 }}
+  {{- end }}
+{{- end }}
 {{- /* Create a job that cleans up after 5 minutes that creates the secret since the user didn't provide one*/}}
 ---
 apiVersion: batch/v1
@@ -107,6 +113,11 @@ spec:
               - key: gen-key.sh
                 path: entry-point.sh
                 mode: 0755
+              {{- range $key, $value := .Values.keygenJob.extraScripts }}
+              - key: {{ $key }}
+                path: {{ $key }}
+                mode: 0755
+              {{- end }}
       containers:
       - volumeMounts:
           - name: script
@@ -127,5 +138,11 @@ spec:
             value: "{{ .Release.Name }}-wg-generated"
           - name: RELEASE_NAMESPACE
             value: "{{ .Release.Namespace }}"
-        command: ["/job/entry-point.sh"]
+          - name: RELEASE_NAME
+            value: "{{ .Release.Name }}"
+          {{- range $key, $value := .Values.keygenJob.extraEnv }}
+          - name: {{ $key }}
+            value: {{ tpl $value $ | quote }}
+          {{- end }}
+        command: {{ .Values.keygenJob.command | toYaml | nindent 10}}
 {{- end }}

--- a/helm/wireguard/templates/privatekey-gen-job.yaml
+++ b/helm/wireguard/templates/privatekey-gen-job.yaml
@@ -144,5 +144,12 @@ spec:
           - name: {{ $key }}
             value: {{ tpl $value $ | quote }}
           {{- end }}
+          {{- range $key, $value := .Values.keygenJob.extraEnvSecrets }}
+          - name: {{ $key }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ tpl $value.secretName $ }}
+                key: {{ tpl $value.secretPropertyName $ }}
+          {{- end }}
         command: {{ .Values.keygenJob.command | toYaml | nindent 10}}
 {{- end }}

--- a/helm/wireguard/templates/privatekey-gen-job.yaml
+++ b/helm/wireguard/templates/privatekey-gen-job.yaml
@@ -91,12 +91,10 @@ spec:
   ttlSecondsAfterFinished: 60
   template:
     spec:
-      securityContext:
-        runAsUser: 1000
-        runAsGroup: 1000
-        fsGroup: 1000
+      {{- include "wireguard.runtimeClass" . | indent 6 }}
       serviceAccountName: {{ .Release.Name }}-pre-install-job-sa
       restartPolicy: Never
+      securityContext: {{ .Values.keygenJob.podSecurityContext | toYaml | nindent 8 }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -114,8 +112,9 @@ spec:
           - name: script
             mountPath: /job/
         name: keygen-job
-        image: "ghcr.io/curium-rocks/wg-kubectl:latest"
-        imagePullPolicy: Always
+        image: "{{ .Values.keygenJob.image.repository }}:{{ .Values.keygenJob.image.tag }}"
+        imagePullPolicy: "{{ .Values.keygenJob.image.pullPolicy }}"
+        securityContext: {{ .Values.keygenJob.containerSecurityContext | toYaml | nindent 10 }}
         resources:
           requests:
             memory: 64Mi

--- a/helm/wireguard/values.yaml
+++ b/helm/wireguard/values.yaml
@@ -2,6 +2,24 @@ image:
   repository: ghcr.io/bryopsida/wireguard
   tag: main
   pullPolicy: Always
+
+keygenJob:
+  image:
+    repository: ghcr.io/curium-rocks/wg-kubectl
+    tag: latest
+    pullPolicy: Always
+  podSecurityContext:
+    seccompProfile:
+      type: RuntimeDefault
+    fsGroup: 1000
+    fsGroupChangePolicy: Always
+  containerSecurityContext:
+    runAsUser: 1000
+    runAsGroup: 1000
+    runAsNonRoot: true
+    privileged: false
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
 podAnnotations: {}
 labels: {}
 wireguard:
@@ -36,6 +54,8 @@ resources:
   limits:
     memory: 256Mi
     cpu: "100m"
+# -- Override the default runtime class of the container, if not provided `runc` will most likely be used
+runtimeClassName: ~
 deploymentStrategy:
   type: 'RollingUpdate'
   rollingUpdate:

--- a/helm/wireguard/values.yaml
+++ b/helm/wireguard/values.yaml
@@ -20,6 +20,12 @@ keygenJob:
     privileged: false
     allowPrivilegeEscalation: false
     readOnlyRootFilesystem: true
+  # -- Specify the script to run to generate the private key
+  command: ["/job/entry-point.sh"]
+  # -- Inject additional scripts into the key generation job
+  extraScripts: {}
+  # -- Add additional environment variables to the key generation job, supports helm templating
+  extraEnv: {}
 podAnnotations: {}
 labels: {}
 wireguard:


### PR DESCRIPTION
What
---
Adds the ability to customize the configuration in a more ways via helm values. Specifically, adds the following extension points.

`keygenJob.image` is added to override the container image used to generate the wg private key.
`keygenJob.podSecurityContext` is added to allowing customizing the pod level security context of the job that generates the private key.
`keygenJob.containerSecurityContext` is added to allowing customizing the container level security context of the job that generates the private key.
`keygenJob.extraEnv` allow injecting environment variables that are available to the keygen hook, helm templates can be used for values.
`keygenJob.extraEnvSecrets` allow setting environment variable values from secret properties
`keygenJob.extraScripts` allow injecting additional/customs scripts for generating the wg private key on install
`keygenJob.command` allow overriding the default command for the keygen hook

`dnsPolicy` is added to allow setting dns policy: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/
`dnsConfig` is added for setting dns config directly: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config
`runtimeClassName` is added to allow specifying the runtime class  (IE gvisor/katacontainer): https://kubernetes.io/docs/concepts/containers/runtime-class/
`securityContext.seccompProfile` is supported
`extraEnv` supports helm templating in values
`extraEnvSecrets` support injecting environment variables from values on secrets

Fixes
---
- Topology spread was not correctly setting labelSelectors and labelKeys, it will now properly try to spread across nodes.