### PR TITLE
feat: option to leave out the serverCidr as nat source

### DIFF
--- a/helm/wireguard/templates/config.yaml
+++ b/helm/wireguard/templates/config.yaml
@@ -1,9 +1,10 @@
 {{- define "wg-config-template" -}}
+{{- $natSourceNetOption := .Values.wireguard.natAddSourceNet | ternary (printf "%s %s" "-s" .Values.wireguard.serverCidr) ("") -}}
 [Interface]
 Address = {{ .Values.wireguard.serverAddress }}
 ListenPort = 51820
-PostUp = wg set wg0 private-key /etc/wireguard/privatekey && iptables -t nat -A POSTROUTING -s {{ .Values.wireguard.serverCidr }} -o eth0 -j MASQUERADE
-PostDown = iptables -t nat -D POSTROUTING -s {{ .Values.wireguard.serverCidr }} -o eth0 -j MASQUERADE
+PostUp = wg set wg0 private-key /etc/wireguard/privatekey && iptables -t nat -A POSTROUTING {{ $natSourceNetOption }} -o eth0 -j MASQUERADE
+PostDown = iptables -t nat -D POSTROUTING -s {{ $natSourceNetOption }} -o eth0 -j MASQUERADE
 
 # Clients
 {{- range .Values.wireguard.clients }}

--- a/helm/wireguard/values.yaml
+++ b/helm/wireguard/values.yaml
@@ -35,6 +35,8 @@ wireguard:
   serverAddress: 10.34.0.1/24
   # -- Subnet for your VPN, take care not to clash with cluster POD cidr
   serverCidr: 10.34.0.0/24
+  # -- Add the serverCidr to the nat source net option
+  natAddSourceNet: true
   # -- A collection of clients that will be added to wg0.conf, accepts objects with keys PublicKey and AllowedIPs (mandatory) and optional FriendlyName or FriendlyJson (https://github.com/MindFlavor/prometheus_wireguard_exporter#friendly-tags), stored in secret
   clients: []
     # - FriendlyName: username1


### PR DESCRIPTION
Hello,

for my use case I need a little change in the wg0.conf. To realize a site-to-site connection it is important to NAT every IP. So I need an option to leave out the serverCidr as the nat source.

Greetings
Klaus