### PR TITLE
Add optional sidecar to expose a http health check

### DIFF
--- a/ci/test-with-healthsidecar-daemonset-hostport.yaml
+++ b/ci/test-with-healthsidecar-daemonset-hostport.yaml
@@ -1,0 +1,9 @@
+healthSideCar:
+  enabled: true
+  service:
+    enabled: false
+  useHostPort: true
+  hostPort: 10000
+autoscaling:
+  enabled: false
+daemonSet: true

--- a/ci/test-with-healthsidecar-nodeport.yaml
+++ b/ci/test-with-healthsidecar-nodeport.yaml
@@ -1,0 +1,7 @@
+healthSideCar:
+  enabled: true
+autoscaling:
+  enabled: false
+replicaCount: 1
+deploymentStrategy:
+  type: Recreate

--- a/helm/wireguard/Chart.yaml
+++ b/helm/wireguard/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wireguard
 description: A Helm chart for managing a wireguard vpn in kubernetes
 type: application
-version: 0.19.0
+version: 0.20.0
 appVersion: "0.0.0"
 maintainers:
   - name: bryopsida

--- a/helm/wireguard/README.md
+++ b/helm/wireguard/README.md
@@ -1,6 +1,6 @@
 # wireguard
 
-![Version: 0.19.0](https://img.shields.io/badge/Version-0.19.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
+![Version: 0.20.0](https://img.shields.io/badge/Version-0.20.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
 
 A Helm chart for managing a wireguard vpn in kubernetes
 
@@ -30,6 +30,18 @@ A Helm chart for managing a wireguard vpn in kubernetes
 | disruptionBudget.enabled | bool | `true` |  |
 | disruptionBudget.minAvailable | int | `2` |  |
 | extraEnv | object | `{}` | Provide additional environment variables to the wireguard container |
+| healthSideCar.enabled | bool | `false` | Opt in side car to expose a http health end point for external load balancers that are not kubernetes aware, in most cases this is not needed |
+| healthSideCar.hostPort | int | `13000` | When useHostPort is true this is the host port defined |
+| healthSideCar.image.pullPolicy | string | `"Always"` | Pull Policy always to avoid cached rolling tags, if you change this you should use a non rolling tag |
+| healthSideCar.image.repository | string | `"ghcr.io/bryopsida/http-healthcheck-sidecar"` | Override repo if you prefer to use your own image |
+| healthSideCar.image.tag | string | `"main"` | Rolling tag used by default to take patches automatically |
+| healthSideCar.resources | object | `{"limits":{"cpu":"100m","memory":"256Mi"},"requests":{"cpu":"100m","memory":"256Mi"}}` | set resource constraints, set to nil to remove |
+| healthSideCar.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsGroup":10001,"runAsNonRoot":true,"runAsUser":10001,"seccompProfile":{"type":"RuntimeDefault"}}` | Secure settings by default, can be overriden to reduce security posture if needed |
+| healthSideCar.service.enabled | bool | `true` | Toggle to enable the service, if the pod is a daemonset healthSideCar.useHostPort can be used instead |
+| healthSideCar.service.nodePort | int | `31313` | The port for the service exposed on each node |
+| healthSideCar.service.port | int | `3000` | Override service port if needed |
+| healthSideCar.service.type | string | `"NodePort"` | Service type, given the use case, in most cases this should be NodePort |
+| healthSideCar.useHostPort | bool | `false` | When enabled the container will define a host port, in most cases this should only be used when deploying with daemonSet: true  |
 | hostPort | int | `51820` | Host port to expose the VPN service on |
 | image.pullPolicy | string | `"Always"` |  |
 | image.repository | string | `"ghcr.io/bryopsida/wireguard"` |  |

--- a/helm/wireguard/README.md
+++ b/helm/wireguard/README.md
@@ -41,7 +41,7 @@ A Helm chart for managing a wireguard vpn in kubernetes
 | healthSideCar.service.nodePort | int | `31313` | The port for the service exposed on each node |
 | healthSideCar.service.port | int | `3000` | Override service port if needed |
 | healthSideCar.service.type | string | `"NodePort"` | Service type, given the use case, in most cases this should be NodePort |
-| healthSideCar.useHostPort | bool | `false` | When enabled the container will define a host port, in most cases this should only be used when deploying with daemonSet: true  |
+| healthSideCar.useHostPort | bool | `false` | When enabled the container will define a host port, in most cases this should only be used when deploying with daemonSet: true |
 | hostPort | int | `51820` | Host port to expose the VPN service on |
 | image.pullPolicy | string | `"Always"` |  |
 | image.repository | string | `"ghcr.io/bryopsida/wireguard"` |  |

--- a/helm/wireguard/templates/deployment.yaml
+++ b/helm/wireguard/templates/deployment.yaml
@@ -104,7 +104,7 @@ spec:
           matchLabelKeys:
             - pod-template-hash
           {{- end }}
-      automountServiceAccountToken: false
+      automountServiceAccountToken: {{ .Values.healthSideCar.enabled }}
       securityContext:
         fsGroup: {{ .Values.securityContext.runAsUser | default 1000 }}
         fsGroupChangePolicy: "OnRootMismatch"
@@ -250,6 +250,20 @@ spec:
           {{- if .Values.volumeMounts }}
             {{- .Values.volumeMounts | toYaml | nindent 10 }}
           {{- end }}
+        {{- end }}
+        {{- if .Values.healthSideCar.enabled }}
+        - name: health
+          image: "{{ .Values.healthSideCar.image.repository }}:{{ .Values.healthSideCar.image.tag }}"
+          imagePullPolicy: "{{ .Values.healthSideCar.image.pullPolicy }}"
+          resources: {{ .Values.healthSideCar.resources | toYaml | nindent 12 }}
+          securityContext: {{ .Values.healthSideCar.securityContext | toYaml | nindent 12 }}
+          ports:
+            - containerPort: 3000
+              protocol: TCP
+              name: wg-health-ep
+              {{- if .Values.healthSideCar.useHostPort }}
+              hostPort: {{ .Values.healthSideCar.hostPort }}
+              {{- end }}
         {{- end }}
       volumes:
       - name: run

--- a/helm/wireguard/templates/sa.yaml
+++ b/helm/wireguard/templates/sa.yaml
@@ -1,5 +1,29 @@
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Release.Name }}-sa
 automountServiceAccountToken: false
+{{- if .Values.healthSideCar.enabled }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}-pod-reader
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-read-pods
+subjects:
+- kind: ServiceAccount
+  name: {{ .Release.Name }}-sa
+roleRef:
+  kind: Role
+  name: {{ .Release.Name }}-pod-reader
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/helm/wireguard/templates/service-health-endpoint.yaml
+++ b/helm/wireguard/templates/service-health-endpoint.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.healthSideCar.enabled  .Values.healthSideCar.service.enabled }}
+kind: Service
+apiVersion: v1
+metadata:
+  name: "{{ .Release.Name }}-healthcheck"
+  labels:
+    app: "{{ .Release.Name }}-healthcheck"
+    app.kubernetes.io/component: health
+    {{- if .Values.healthSideCar.service.labels }}
+    {{- toYaml .Values.healthSideCar.service.labels | nindent 4 }}
+    {{- end }}
+  {{- if .Values.healthSideCar.service.annotations }}
+  annotations:
+    {{- toYaml .Values.healthSideCar.service.annotations | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.healthSideCar.service.type }}
+  ports:
+  - name: 
+    protocol: TCP
+    port: {{ .Values.healthSideCar.service.port }}
+    targetPort: 3000
+    {{- if eq .Values.healthSideCar.service.type "NodePort" }}
+    nodePort: {{ .Values.healthSideCar.service.nodePort }}
+    {{- end }}
+  selector:
+    app: "{{ .Release.Name }}-wireguard"
+{{- end }}

--- a/helm/wireguard/values.yaml
+++ b/helm/wireguard/values.yaml
@@ -228,3 +228,47 @@ metrics:
     # -- Grafana dashboard annotations
     annotations: {}
       # k8s-sidecar-target-directory: /tmp/dashboards/Other
+## Health sidecar configuration
+healthSideCar:
+  # -- Opt in side car to expose a http health end point for external load balancers that are not kubernetes aware, in most cases this is not needed
+  enabled: false
+  # -- Secure settings by default, can be overriden to reduce security posture if needed
+  securityContext:
+    capabilities:
+      drop:
+        - ALL
+    runAsGroup: 10001
+    runAsUser: 10001
+    seccompProfile:
+      type: RuntimeDefault
+    runAsNonRoot: true
+    readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+  # -- set resource constraints, set to nil to remove
+  resources:
+    requests:
+      memory: 256Mi
+      cpu: "100m"
+    limits:
+      memory: 256Mi
+      cpu: "100m"
+  image:
+    # -- Override repo if you prefer to use your own image
+    repository: ghcr.io/bryopsida/http-healthcheck-sidecar
+    # -- Rolling tag used by default to take patches automatically
+    tag: main
+    # -- Pull Policy always to avoid cached rolling tags, if you change this you should use a non rolling tag
+    pullPolicy: Always
+  service:
+    # -- Override service port if needed
+    port: 3000
+    # -- Toggle to enable the service, if the pod is a daemonset healthSideCar.useHostPort can be used instead
+    enabled: true
+    # -- Service type, given the use case, in most cases this should be NodePort
+    type: NodePort
+    # -- The port for the service exposed on each node
+    nodePort: 31313
+  # -- When enabled the container will define a host port, in most cases this should only be used when deploying with daemonSet: true 
+  useHostPort: false
+  # -- When useHostPort is true this is the host port defined
+  hostPort: 13000

--- a/helm/wireguard/values.yaml
+++ b/helm/wireguard/values.yaml
@@ -268,7 +268,7 @@ healthSideCar:
     type: NodePort
     # -- The port for the service exposed on each node
     nodePort: 31313
-  # -- When enabled the container will define a host port, in most cases this should only be used when deploying with daemonSet: true 
+  # -- When enabled the container will define a host port, in most cases this should only be used when deploying with daemonSet: true
   useHostPort: false
   # -- When useHostPort is true this is the host port defined
   hostPort: 13000


### PR DESCRIPTION
Adds an optional health side car that can used to expose a health check end point to a external load balancer that's not K8S aware.

Related to: #43 