### PR TITLE
Add pass through options for extra side cars and service ports

### DIFF
--- a/ci/test-with-extra-sidecar.yaml
+++ b/ci/test-with-extra-sidecar.yaml
@@ -1,0 +1,83 @@
+# with host network used, a service object is not needed
+service:
+  enabled: false
+replicaCount: 1
+autoscaling:
+  enabled: false
+deploymentStrategy:
+  type: "Recreate"
+# create storage volumes for wg-portal sql lite database
+extraStorage:
+  - name: wg-portal-data
+    storage: 8Gi
+    # omitting storage class and using default, if you need
+    # to target a particular storage class specify this
+    # storageClassName: some-storage-class
+    accessModes:
+      # ReadWriteOnce is used for easy testing,
+      # if you are going to run multiple pods this needs to be
+      # ReadWriteMany and you'll need a storage system that supports this
+      - ReadWriteOnce
+    volumeMode: Filesystem
+# wg-portal docs use host network and NET_ADMIN
+runPodOnHostNetwork: true
+extraConfigMaps:
+  - name: wg-portal-config
+    data:
+      # this is from the sample config file in the wg-portal repo
+      # as a placeholder in testing
+      # be sure to adjust the external_url to something appropriate for your
+      # network
+      config.yml: |
+        advanced:
+          log_level: trace
+
+        core:
+          admin_user: admin
+          admin_password: wgportal
+          create_default_peer: true
+          create_default_peer_on_creation: false
+
+        web:
+          external_url: http://localhost:8888
+          request_logging: true
+# we need to mount/attach the storage to the pod
+volumes:
+  - name: wg-portal-data
+    persistentVolumeClaim:
+      claimName: wg-portal-data
+  - name: wg-portal-config
+    configMap:
+      name: wg-portal-config
+# add wg-portal side car
+extraSideCars:
+  - name: wg-portal
+    image: wgportal/wg-portal
+    imagePullPolicy: Always
+    securityContext:
+      # wg-portal runs as root and enumerates devices
+      #   as far as I can tell it requires high level access to the node
+      #   to function
+      runAsNonRoot: false
+      capabilities:
+        add:
+          - NET_ADMIN
+    ports:
+      - containerPort: 8888
+        protocol: TCP
+        name: http
+    # we need to mount the pod volume into the side car
+    volumeMounts:
+      - mountPath: "/app/config"
+        name: wg-portal-config
+      - mountPath: "/app/data"
+        name: wg-portal-data
+      # assuming the generated wg key secret is used
+      # and the default wg0.conf management is used
+      # need to project the following into /etc/wireguard for wg-portal
+      - name: config
+        mountPath: /etc/wireguard/wg0.conf
+        subPath: wg0.conf
+      - name: privatekey
+        mountPath: /etc/wireguard/privatekey
+        subPath: privatekey

--- a/helm/wireguard/Chart.yaml
+++ b/helm/wireguard/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wireguard
 description: A Helm chart for managing a wireguard vpn in kubernetes
 type: application
-version: 0.22.0
+version: 0.23.0
 appVersion: "0.0.0"
 maintainers:
   - name: bryopsida

--- a/helm/wireguard/README.md
+++ b/helm/wireguard/README.md
@@ -1,6 +1,6 @@
 # wireguard
 
-![Version: 0.22.0](https://img.shields.io/badge/Version-0.22.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
+![Version: 0.23.0](https://img.shields.io/badge/Version-0.23.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
 
 A Helm chart for managing a wireguard vpn in kubernetes
 
@@ -30,6 +30,7 @@ A Helm chart for managing a wireguard vpn in kubernetes
 | disruptionBudget.enabled | bool | `true` |  |
 | disruptionBudget.minAvailable | int | `2` |  |
 | extraEnv | object | `{}` | Provide additional environment variables to the wireguard container |
+| extraSideCars | list | `[]` | Provide additional sidecars to the wireguard pod, these are directly attached to the pod and must be well formed ContainerSpec |
 | healthSideCar.enabled | bool | `false` | Opt in side car to expose a http health end point for external load balancers that are not kubernetes aware, in most cases this is not needed |
 | healthSideCar.hostPort | int | `13000` | When useHostPort is true this is the host port defined |
 | healthSideCar.image.pullPolicy | string | `"Always"` | Pull Policy always to avoid cached rolling tags, if you change this you should use a non rolling tag |
@@ -113,6 +114,7 @@ A Helm chart for managing a wireguard vpn in kubernetes
 | service.annotations | object | `{}` | Annotations |
 | service.enabled | bool | `true` | Whether the service will be created or not |
 | service.externalTrafficPolicy | string | `""` | External Traffic Policy for the service |
+| service.extraPorts | list | `[]` | Extra ports that can be attached to the service object, these are passed directly to the port array on the service and must be well formed to the specification |
 | service.loadBalancerIP | string | `""` | IP to assign to the LoadBalancer service |
 | service.nodePort | int | `31820` | Node port, only valid with service type: NodePort |
 | service.port | int | `51820` | Service port, default is 51820 UDP |

--- a/helm/wireguard/README.md
+++ b/helm/wireguard/README.md
@@ -29,8 +29,10 @@ A Helm chart for managing a wireguard vpn in kubernetes
 | disablePrivateKeyManagement | bool | `false` | Disable creation and any mounting of a private key, this assumes another mechanism is provided/used at the container level to fetch the private key |
 | disruptionBudget.enabled | bool | `true` |  |
 | disruptionBudget.minAvailable | int | `2` |  |
+| extraConfigMaps | list | `[]` | Create additional configmaps that may be used in sidecars |
 | extraEnv | object | `{}` | Provide additional environment variables to the wireguard container |
 | extraSideCars | list | `[]` | Provide additional sidecars to the wireguard pod, these are directly attached to the pod and must be well formed ContainerSpec |
+| extraStorage | list | `[]` | Create storage claims that can be used by side cars |
 | healthSideCar.enabled | bool | `false` | Opt in side car to expose a http health end point for external load balancers that are not kubernetes aware, in most cases this is not needed |
 | healthSideCar.hostPort | int | `13000` | When useHostPort is true this is the host port defined |
 | healthSideCar.image.pullPolicy | string | `"Always"` | Pull Policy always to avoid cached rolling tags, if you change this you should use a non rolling tag |
@@ -104,6 +106,7 @@ A Helm chart for managing a wireguard vpn in kubernetes
 | resources.limits.memory | string | `"256Mi"` |  |
 | resources.requests.cpu | string | `"100m"` |  |
 | resources.requests.memory | string | `"256Mi"` |  |
+| runPodOnHostNetwork | bool | `false` | Run pod on host network |
 | runtimeClassName | string | `nil` | Override the default runtime class of the container, if not provided `runc` will most likely be used |
 | secretName | string | `nil` | Name of a secret with a wireguard private key on key privatekey, if not provided on first install a hook generates one. |
 | securityContext.allowPrivilegeEscalation | bool | `true` |  |

--- a/helm/wireguard/templates/deployment.yaml
+++ b/helm/wireguard/templates/deployment.yaml
@@ -265,6 +265,11 @@ spec:
               hostPort: {{ .Values.healthSideCar.hostPort }}
               {{- end }}
         {{- end }}
+        {{- if .Values.extraSideCars }}
+        {{- range .Values.extraSideCars }}
+        {{- . | toYaml | nindent 10 }}
+        {{- end }}
+        {{- end }}
       volumes:
       - name: run
         emptyDir: {}

--- a/helm/wireguard/templates/deployment.yaml
+++ b/helm/wireguard/templates/deployment.yaml
@@ -105,6 +105,9 @@ spec:
             - pod-template-hash
           {{- end }}
       automountServiceAccountToken: {{ .Values.healthSideCar.enabled }}
+      {{- if .Values.runPodOnHostNetwork }}
+      hostNetwork: true
+      {{- end }}
       securityContext:
         fsGroup: {{ .Values.securityContext.runAsUser | default 1000 }}
         fsGroupChangePolicy: "OnRootMismatch"
@@ -266,9 +269,7 @@ spec:
               {{- end }}
         {{- end }}
         {{- if .Values.extraSideCars }}
-        {{- range .Values.extraSideCars }}
-        {{- . | toYaml | nindent 10 }}
-        {{- end }}
+        {{- .Values.extraSideCars | toYaml | nindent 8 }}
         {{- end }}
       volumes:
       - name: run

--- a/helm/wireguard/templates/extra-config-maps.yaml
+++ b/helm/wireguard/templates/extra-config-maps.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.extraConfigMaps }}
+{{- range .Values.extraConfigMaps }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .name }}
+  namespace: {{ $.Release.Namespace }}
+data: {{ .data | toYaml | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/helm/wireguard/templates/extra-storage.yaml
+++ b/helm/wireguard/templates/extra-storage.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.extraStorage }}
+{{- range .Values.extraStorage }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .name }}
+  namespace: {{ $.Release.Namespace }}
+  annotations:
+    "helm.sh/resource-policy": keep
+spec:
+  {{- if .storageClassName }}
+  storageClassName: {{ .storageClassName }} 
+  {{- end }}
+  {{- if .volumeName }}
+  volumeName: {{ .volumeName }}
+  {{- end }}
+  accessModes: {{ .accessModes | toYaml | nindent 4 }}
+  volumeMode: {{ .volumeMode }}
+  resources:
+    requests:
+      storage: {{ .storage }}
+{{- end }}
+{{- end }}

--- a/helm/wireguard/templates/service.yaml
+++ b/helm/wireguard/templates/service.yaml
@@ -12,12 +12,17 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
-  - name: wg
-    protocol: UDP
-    port: {{ .Values.service.port }}
-    targetPort: 51820
-    {{- if .Values.service.type | eq "NodePort" }}
-    nodePort: {{ .Values.service.nodePort }}
+    - name: wg
+      protocol: UDP
+      port: {{ .Values.service.port }}
+      targetPort: 51820
+      {{- if .Values.service.type | eq "NodePort" }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
+    {{- if .Values.service.extraPorts }}
+    {{- range .Values.service.extraPorts }}
+    {{ . | toYaml | nindent 6 }}
+    {{- end }}
     {{- end }}
   selector:
     app: "{{ .Release.Name }}-wireguard"

--- a/helm/wireguard/templates/service.yaml
+++ b/helm/wireguard/templates/service.yaml
@@ -20,9 +20,7 @@ spec:
       nodePort: {{ .Values.service.nodePort }}
       {{- end }}
     {{- if .Values.service.extraPorts }}
-    {{- range .Values.service.extraPorts }}
-    {{ . | toYaml | nindent 6 }}
-    {{- end }}
+    {{- .Values.service.extraPorts | toYaml | nindent 4 }}
     {{- end }}
   selector:
     app: "{{ .Release.Name }}-wireguard"

--- a/helm/wireguard/values.yaml
+++ b/helm/wireguard/values.yaml
@@ -72,6 +72,8 @@ service:
   loadBalancerIP: ""
   # -- Annotations
   annotations: {}
+  # -- Extra ports that can be attached to the service object, these are passed directly to the port array on the service and must be well formed to the specification
+  extraPorts: []
 # -- Name of a secret with a wireguard private key on key privatekey, if not provided on first install a hook generates one.
 secretName: ~
 replicaCount: 3
@@ -99,6 +101,8 @@ autoscaling:
   targetCPUUtilizationPercentage: 75
 # -- Provide additional environment variables to the wireguard container
 extraEnv: {}
+# -- Provide additional sidecars to the wireguard pod, these are directly attached to the pod and must be well formed ContainerSpec
+extraSideCars: []
 #  TEST_ENV_VAR: test-value
 # -- If provided, this secret will be used instead of the config created from the helm value scope
 configSecretName: ~

--- a/helm/wireguard/values.yaml
+++ b/helm/wireguard/values.yaml
@@ -30,6 +30,8 @@ keygenJob:
   extraEnv: {}
 podAnnotations: {}
 labels: {}
+# -- Run pod on host network
+runPodOnHostNetwork: false
 # -- Expose VPN service on hostPort
 useHostPort: false
 # -- Host port to expose the VPN service on
@@ -101,9 +103,23 @@ autoscaling:
   targetCPUUtilizationPercentage: 75
 # -- Provide additional environment variables to the wireguard container
 extraEnv: {}
+#  TEST_ENV_VAR: test-value
 # -- Provide additional sidecars to the wireguard pod, these are directly attached to the pod and must be well formed ContainerSpec
 extraSideCars: []
-#  TEST_ENV_VAR: test-value
+# -- Create storage claims that can be used by side cars
+extraStorage: []
+# - name: conf
+#   storageClassName: default
+#   storage: 8Gi
+#   accessModes:
+#     - ReadWriteMany
+#   volumeMode: Filesystem
+# -- Create additional configmaps that may be used in sidecars
+extraConfigMaps: []
+# - name: some-config
+#    data:
+#      key1: |
+#        some config file data
 # -- If provided, this secret will be used instead of the config created from the helm value scope
 configSecretName: ~
 # -- The property/key on the secret holding the wireguard configuration file


### PR DESCRIPTION
What
---
To allow more flexibility, provide value options to extend the pod with sidecars and service ports.

Evidence
----
### Render with extra sidecars

Relates to:  #52, to start with, provide value options and document how to use the values to setup a side car for the management UI and expose it over service + ingress objects. This way users can pick their preferred management UI as there are several out there. Current releases/users should not be impacted and it should be an opt in.