### PR TITLE
Added LoadbalancerClass (1.22)

### DIFF
--- a/helm/wireguard/Chart.yaml
+++ b/helm/wireguard/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wireguard
 description: A Helm chart for managing a wireguard vpn in kubernetes
 type: application
-version: 0.26.0
+version: 0.27.0
 appVersion: "0.0.0"
 maintainers:
   - name: bryopsida

--- a/helm/wireguard/README.md
+++ b/helm/wireguard/README.md
@@ -110,7 +110,7 @@ A Helm chart for managing a wireguard vpn in kubernetes
 | resources.requests.memory | string | `"256Mi"` |  |
 | runPodOnHostNetwork | bool | `false` | Run pod on host network |
 | runtimeClassName | string | `nil` | Override the default runtime class of the container, if not provided `runc` will most likely be used |
-| secretName | string | `nil` | Name of a secret with a wireguard private key on key privatekey, if not provided on first install a hook generates one. |
+| secretName | string | `nil` | Name of a secret with a wireguard private key on key privatekey, if not provided on first install a hook generates one |
 | securityContext.allowPrivilegeEscalation | bool | `true` |  |
 | securityContext.privileged | bool | `false` |  |
 | securityContext.readOnlyRootFilesystem | bool | `true` |  |
@@ -120,6 +120,7 @@ A Helm chart for managing a wireguard vpn in kubernetes
 | service.enabled | bool | `true` | Whether the service will be created or not |
 | service.externalTrafficPolicy | string | `""` | External Traffic Policy for the service |
 | service.extraPorts | list | `[]` | Extra ports that can be attached to the service object, these are passed directly to the port array on the service and must be well formed to the specification |
+| service.loadBalancerClass | string | `""` | loadBalancerClass for kubernetes clusters with multiple load balancer classes. This value cannot be used in a upgrade flow |
 | service.loadBalancerIP | string | `""` | IP to assign to the LoadBalancer service |
 | service.nodePort | int | `31820` | Node port, only valid with service type: NodePort |
 | service.port | int | `51820` | Service port, default is 51820 UDP |

--- a/helm/wireguard/templates/service.yaml
+++ b/helm/wireguard/templates/service.yaml
@@ -30,4 +30,7 @@ spec:
   {{- if .Values.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   {{- end }}
+  {{- if .Values.service.loadBalancerClass }}
+  loadBalancerClass: {{ .Values.service.loadBalancerClass }}
+  {{- end }}
 {{- end }}

--- a/helm/wireguard/values.yaml
+++ b/helm/wireguard/values.yaml
@@ -87,9 +87,9 @@ service:
   annotations: {}
   # -- Extra ports that can be attached to the service object, these are passed directly to the port array on the service and must be well formed to the specification
   extraPorts: []
-  # -- loadBalancerClass for Service Controllers that support it
+  # -- loadBalancerClass for kubernetes clusters with multiple load balancer classes. This value cannot be used in a upgrade flow
   loadBalancerClass: ""
-# -- Name of a secret with a wireguard private key on key privatekey, if not provided on first install a hook generates one.
+# -- Name of a secret with a wireguard private key on key privatekey, if not provided on first install a hook generates one
 secretName: ~
 replicaCount: 3
 resources:

--- a/helm/wireguard/values.yaml
+++ b/helm/wireguard/values.yaml
@@ -87,6 +87,8 @@ service:
   annotations: {}
   # -- Extra ports that can be attached to the service object, these are passed directly to the port array on the service and must be well formed to the specification
   extraPorts: []
+  # -- loadBalancerClass for Service Controllers that support it
+  loadBalancerClass: ""
 # -- Name of a secret with a wireguard private key on key privatekey, if not provided on first install a hook generates one.
 secretName: ~
 replicaCount: 3


### PR DESCRIPTION
As part part of the service spec, if the user sets service.loadbalancerClass it will add loadbalancerClass to the spec of the service and add the value from the charts values.

This configuration option comes in when you have a cluster with multiple Loadbalancer Controllers. For example MetalLB and ELB.

All cloudprovider controllers integrate with this service today.