### PR TITLE
Make job, initContainer, metrics resources configurable 

### DIFF
--- a/helm/wireguard/Chart.yaml
+++ b/helm/wireguard/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wireguard
 description: A Helm chart for managing a wireguard vpn in kubernetes
 type: application
-version: 0.28.0
+version: 0.29.0
 appVersion: "0.0.0"
 maintainers:
   - name: bryopsida

--- a/helm/wireguard/README.md
+++ b/helm/wireguard/README.md
@@ -1,6 +1,6 @@
 # wireguard
 
-![Version: 0.28.0](https://img.shields.io/badge/Version-0.28.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
+![Version: 0.29.0](https://img.shields.io/badge/Version-0.29.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
 
 A Helm chart for managing a wireguard vpn in kubernetes
 
@@ -38,7 +38,7 @@ A Helm chart for managing a wireguard vpn in kubernetes
 | healthSideCar.image.pullPolicy | string | `"Always"` | Pull Policy always to avoid cached rolling tags, if you change this you should use a non rolling tag |
 | healthSideCar.image.repository | string | `"ghcr.io/bryopsida/http-healthcheck-sidecar"` | Override repo if you prefer to use your own image |
 | healthSideCar.image.tag | string | `"main"` | Rolling tag used by default to take patches automatically |
-| healthSideCar.resources | object | `{"limits":{"cpu":"100m","memory":"256Mi"},"requests":{"cpu":"100m","memory":"256Mi"}}` | set resource constraints, set to nil to remove |
+| healthSideCar.resources | object | `{"limits":{"cpu":"100m","ephemeral-storage":"256Mi","memory":"256Mi"},"requests":{"cpu":"100m","ephemeral-storage":"8Mi","memory":"256Mi"}}` | set resource constraints, set to nil to remove |
 | healthSideCar.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsGroup":10001,"runAsNonRoot":true,"runAsUser":10001,"seccompProfile":{"type":"RuntimeDefault"}}` | Secure settings by default, can be overriden to reduce security posture if needed |
 | healthSideCar.service.enabled | bool | `true` | Toggle to enable the service, if the pod is a daemonset healthSideCar.useHostPort can be used instead |
 | healthSideCar.service.nodePort | int | `31313` | The port for the service exposed on each node |
@@ -51,6 +51,12 @@ A Helm chart for managing a wireguard vpn in kubernetes
 | image.tag | string | `"main"` |  |
 | initContainer.image.repository | string | `"busybox"` |  |
 | initContainer.image.tag | string | `"latest"` |  |
+| initContainer.resources.limits.cpu | string | `"100m"` |  |
+| initContainer.resources.limits.ephemeral-storage | string | `"64Mi"` |  |
+| initContainer.resources.limits.memory | string | `"64Mi"` |  |
+| initContainer.resources.requests.cpu | string | `"100m"` |  |
+| initContainer.resources.requests.ephemeral-storage | string | `"8Mi"` |  |
+| initContainer.resources.requests.memory | string | `"64Mi"` |  |
 | keygenJob.command | list | `["/job/entry-point.sh"]` | Specify the script to run to generate the private key |
 | keygenJob.containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
 | keygenJob.containerSecurityContext.privileged | bool | `false` |  |
@@ -63,9 +69,16 @@ A Helm chart for managing a wireguard vpn in kubernetes
 | keygenJob.image.pullPolicy | string | `"Always"` |  |
 | keygenJob.image.repository | string | `"ghcr.io/curium-rocks/wg-kubectl"` |  |
 | keygenJob.image.tag | string | `"latest"` |  |
+| keygenJob.podAnnotations | object | `{}` |  |
 | keygenJob.podSecurityContext.fsGroup | int | `1000` |  |
 | keygenJob.podSecurityContext.fsGroupChangePolicy | string | `"Always"` |  |
 | keygenJob.podSecurityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
+| keygenJob.resources.limits.cpu | string | `"100m"` |  |
+| keygenJob.resources.limits.ephemeral-storage | string | `"128Mi"` |  |
+| keygenJob.resources.limits.memory | string | `"256Mi"` |  |
+| keygenJob.resources.requests.cpu | string | `"100m"` |  |
+| keygenJob.resources.requests.ephemeral-storage | string | `"8Mi"` |  |
+| keygenJob.resources.requests.memory | string | `"256Mi"` |  |
 | keygenJob.useWireguardManager | bool | `false` | when enabled, uses a image with go bindings for k8s and wg    to create the secret if it does not exist, on re-runs it    it leaves the existing secret in place and exits succesfully |
 | keygenJob.wireguardMgrImage | object | `{"pullPolicy":"Always","repository":"ghcr.io/bryopsida/k8s-wireguard-mgr","tag":"main"}` | When useWireguardManager is enabled this image is used instead of the kubectl image |
 | labels | object | `{}` |  |
@@ -87,6 +100,12 @@ A Helm chart for managing a wireguard vpn in kubernetes
 | metrics.prometheusRule.groups | list | `[]` | Groups, containing the alert rules. Example:   groups:     - name: Wireguard       rules:         - alert: WireguardInstanceNotAvailable           annotations:             message: "Wireguard instance in namespace {{ `{{` }} $labels.namespace {{ `}}` }} has not been available for the last 5 minutes."           expr: |             absent(kube_pod_status_ready{namespace="{{ include "common.names.namespace" . }}", condition="true"} * on (pod) kube_pod_labels{pod=~"{{ include "common.names.fullname" . }}-\\d+", namespace="{{ include "common.names.namespace" . }}"}) != 0           for: 5m           labels:             severity: critical |
 | metrics.prometheusRule.labels | object | `{}` | Additional labels that can be used so PrometheusRule will be discovered by Prometheus |
 | metrics.prometheusRule.namespace | string | `""` | Namespace of the ServiceMonitor. If empty, current namespace is used |
+| metrics.resources.limits.cpu | string | `"100m"` |  |
+| metrics.resources.limits.ephemeral-storage | string | `"128Mi"` |  |
+| metrics.resources.limits.memory | string | `"256Mi"` |  |
+| metrics.resources.requests.cpu | string | `"100m"` |  |
+| metrics.resources.requests.ephemeral-storage | string | `"8Mi"` |  |
+| metrics.resources.requests.memory | string | `"256Mi"` |  |
 | metrics.service.annotations | object | `{}` | Annotations for enabling prometheus to access the metrics endpoints |
 | metrics.service.labels | object | `{}` | Additional service labels |
 | metrics.service.port | int | `9586` | Metrics service HTTP port |
@@ -107,8 +126,10 @@ A Helm chart for managing a wireguard vpn in kubernetes
 | podAnnotations | object | `{}` |  |
 | replicaCount | int | `3` |  |
 | resources.limits.cpu | string | `"100m"` |  |
+| resources.limits.ephemeral-storage | string | `"128Mi"` |  |
 | resources.limits.memory | string | `"256Mi"` |  |
 | resources.requests.cpu | string | `"100m"` |  |
+| resources.requests.ephemeral-storage | string | `"8Mi"` |  |
 | resources.requests.memory | string | `"256Mi"` |  |
 | runPodOnHostNetwork | bool | `false` | Run pod on host network |
 | runtimeClassName | string | `nil` | Override the default runtime class of the container, if not provided `runc` will most likely be used |

--- a/helm/wireguard/templates/deployment.yaml
+++ b/helm/wireguard/templates/deployment.yaml
@@ -136,13 +136,7 @@ spec:
           - -c
           - sysctl -w net.ipv4.ip_forward=1 && sysctl -w net.ipv4.conf.all.forwarding=1
           securityContext: {{ include "init.securitycontext" . | nindent 12 }}
-          resources:
-            requests:
-              memory: 64Mi
-              cpu: "100m"
-            limits:
-              memory: 64Mi
-              cpu: "100m"
+          resources: {{ .Values.initContainer.resources | toYaml | nindent 12 }}
       containers:
         - name: wireguard
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -218,7 +212,7 @@ spec:
           - name: PROMETHEUS_WIREGUARD_EXPORTER_PORT
             value: "{{ .Values.metrics.service.port }}"
           securityContext: {{ include "wg.securitycontext" . | nindent 12 }}
-          resources: {{ .Values.resources | toYaml | nindent 12 }}
+          resources: {{ .Values.metrics.resources | toYaml | nindent 12 }}
           startupProbe:
             httpGet:
               path: /metrics

--- a/helm/wireguard/templates/privatekey-gen-job.yaml
+++ b/helm/wireguard/templates/privatekey-gen-job.yaml
@@ -96,6 +96,13 @@ metadata:
 spec:
   ttlSecondsAfterFinished: 60
   template:
+    metadata:
+        {{- if .Values.keygenJob.podAnnotations }}
+      annotations:
+        {{- range $key, $value := .Values.keygenJob.podAnnotations  }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+        {{- end }}
     spec:
       {{- include "wireguard.runtimeClass" . | indent 6 }}
       serviceAccountName: {{ .Release.Name }}-pre-install-job-sa
@@ -131,13 +138,7 @@ spec:
         imagePullPolicy: "{{ .Values.keygenJob.wireguardMgrImage.pullPolicy }}"
         {{- end }}
         securityContext: {{ .Values.keygenJob.containerSecurityContext | toYaml | nindent 10 }}
-        resources:
-          requests:
-            memory: 64Mi
-            cpu: "100m"
-          limits:
-            memory: 64Mi
-            cpu: "100m"
+        resources: {{ .Values.keygenJob.resources | toYaml | nindent 10 }}
         env:
           {{- if .Values.keygenJob.useWireguardManager }}
           - name: K8S_WG_MGR_SERVER_SECRET_NAME

--- a/helm/wireguard/values.yaml
+++ b/helm/wireguard/values.yaml
@@ -9,7 +9,15 @@ initContainer:
   image:
     repository: busybox
     tag: latest
-
+  resources:
+    requests:
+      memory: 64Mi
+      cpu: "100m"
+      ephemeral-storage: 8Mi
+    limits:
+      memory: 64Mi
+      cpu: "100m"
+      ephemeral-storage: 64Mi
 keygenJob:
   # -- when enabled, uses a image with go bindings for k8s and wg
   #    to create the secret if it does not exist, on re-runs it
@@ -24,6 +32,7 @@ keygenJob:
     repository: ghcr.io/curium-rocks/wg-kubectl
     tag: latest
     pullPolicy: Always
+  podAnnotations: {}
   podSecurityContext:
     seccompProfile:
       type: RuntimeDefault
@@ -36,6 +45,15 @@ keygenJob:
     privileged: false
     allowPrivilegeEscalation: false
     readOnlyRootFilesystem: true
+  resources:
+    requests:
+      memory: 256Mi
+      cpu: "100m"
+      ephemeral-storage: 8Mi
+    limits:
+      memory: 256Mi
+      cpu: "100m"
+      ephemeral-storage: 128Mi
   # -- Specify the script to run to generate the private key
   command: ["/job/entry-point.sh"]
   # -- Inject additional scripts into the key generation job
@@ -101,9 +119,11 @@ resources:
   requests:
     memory: 256Mi
     cpu: "100m"
+    ephemeral-storage: 8Mi
   limits:
     memory: 256Mi
     cpu: "100m"
+    ephemeral-storage: 128Mi
 # -- Override the default runtime class of the container, if not provided `runc` will most likely be used
 runtimeClassName: ~
 deploymentStrategy:
@@ -182,6 +202,15 @@ metrics:
     repository: docker.io/mindflavor/prometheus-wireguard-exporter
     tag: 3.6.6
     pullPolicy: IfNotPresent
+  resources:
+    requests:
+      memory: 256Mi
+      cpu: "100m"
+      ephemeral-storage: 8Mi
+    limits:
+      memory: 256Mi
+      cpu: "100m"
+      ephemeral-storage: 128Mi
   # @params -- Wireguard Exporter environment variables. See https://mindflavor.github.io/prometheus_wireguard_exporter
   extraEnv:
     # -- Enable verbose mode
@@ -293,9 +322,11 @@ healthSideCar:
     requests:
       memory: 256Mi
       cpu: "100m"
+      ephemeral-storage: 8Mi
     limits:
       memory: 256Mi
       cpu: "100m"
+      ephemeral-storage: 256Mi
   image:
     # -- Override repo if you prefer to use your own image
     repository: ghcr.io/bryopsida/http-healthcheck-sidecar


### PR DESCRIPTION
It is a good practice to configure the ephemeral-storage limits and requests for containers in addition to memory and CPU.
Also some containers had hard coded values for the resource limits and requests.
Metrics container was not possible to configure separately from the main container.
I also need to set the annotations for the pod created by the Job.

I hope i set some sane default to the requests, please adjust as You see fit.