### PR TITLE
Privatekey gen job success when secret exists. More granular RBAC.

### DIFF
--- a/helm/wireguard/Chart.yaml
+++ b/helm/wireguard/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wireguard
 description: A Helm chart for managing a wireguard vpn in kubernetes
 type: application
-version: 0.29.0
+version: 0.30.0
 appVersion: "0.0.0"
 maintainers:
   - name: bryopsida

--- a/helm/wireguard/scripts/gen-key.sh
+++ b/helm/wireguard/scripts/gen-key.sh
@@ -1,2 +1,8 @@
 #!/usr/bin/env sh
+kubectl get secret --namespace $RELEASE_NAMESPACE $SECRET_NAME > /dev/null
+if [ $? -eq 0 ] 
+then
+    echo "Secret $RELEASE_NAMESPACE/$SECRET_NAME already exists. Not chaging it."
+    exit 0
+fi
 kubectl --namespace $RELEASE_NAMESPACE create secret generic $SECRET_NAME --from-literal=privatekey=$(wg genkey)

--- a/helm/wireguard/templates/privatekey-gen-job.yaml
+++ b/helm/wireguard/templates/privatekey-gen-job.yaml
@@ -19,7 +19,8 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["secrets"]
-  verbs: ["create"]
+  verbs: ["create", "get"]
+  resourceNames: ["{{ .Release.Name }}-wg-generated"]
 {{- /* Need a service account for the job/hook */}}
 ---
 apiVersion: v1


### PR DESCRIPTION
When installing the chart and the private key secret already exists this would cause the job to fail. I think it should succeed with a message that is already exists.

This also causes ArgoCD setups to fail because they will re-create the job and the application sync will fail due to the failure of the job.

This PR will make the job check if secret exists and exit successfully if it does without changing the secret.

I also made the RBAC for the job more granular allowing only access to the specific secret not all secrets in the namespace.