### PR TITLE
feat(keygen-job): use wg mgr by default

### DIFF
--- a/helm/wireguard/Chart.yaml
+++ b/helm/wireguard/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wireguard
 description: A Helm chart for managing a wireguard vpn in kubernetes
 type: application
-version: 0.29.0
+version: 0.30.0
 appVersion: "0.0.0"
 maintainers:
   - name: bryopsida

--- a/helm/wireguard/README.md
+++ b/helm/wireguard/README.md
@@ -79,7 +79,7 @@ A Helm chart for managing a wireguard vpn in kubernetes
 | keygenJob.resources.requests.cpu | string | `"100m"` |  |
 | keygenJob.resources.requests.ephemeral-storage | string | `"8Mi"` |  |
 | keygenJob.resources.requests.memory | string | `"256Mi"` |  |
-| keygenJob.useWireguardManager | bool | `true` | when enabled, uses a image with go bindings for k8s and wg    to create the secret if it does not exist, on re-runs it    it leaves the existing secret in place and exits succesfully |
+| keygenJob.useWireguardManager | bool | `true` | when enabled, uses a image with go bindings for k8s and wg    to create the secret if it does not exist, on re-runs it     leaves the existing secret in place and exits succesfully |
 | keygenJob.wireguardMgrImage | object | `{"pullPolicy":"Always","repository":"ghcr.io/bryopsida/k8s-wireguard-mgr","tag":"main"}` | When useWireguardManager is enabled this image is used instead of the kubectl image |
 | labels | object | `{}` |  |
 | metrics.dashboard.annotations | object | `{}` | Grafana dashboard annotations |

--- a/helm/wireguard/README.md
+++ b/helm/wireguard/README.md
@@ -1,6 +1,6 @@
 # wireguard
 
-![Version: 0.29.0](https://img.shields.io/badge/Version-0.29.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
+![Version: 0.30.0](https://img.shields.io/badge/Version-0.30.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
 
 A Helm chart for managing a wireguard vpn in kubernetes
 
@@ -79,7 +79,7 @@ A Helm chart for managing a wireguard vpn in kubernetes
 | keygenJob.resources.requests.cpu | string | `"100m"` |  |
 | keygenJob.resources.requests.ephemeral-storage | string | `"8Mi"` |  |
 | keygenJob.resources.requests.memory | string | `"256Mi"` |  |
-| keygenJob.useWireguardManager | bool | `false` | when enabled, uses a image with go bindings for k8s and wg    to create the secret if it does not exist, on re-runs it    it leaves the existing secret in place and exits succesfully |
+| keygenJob.useWireguardManager | bool | `true` | when enabled, uses a image with go bindings for k8s and wg    to create the secret if it does not exist, on re-runs it    it leaves the existing secret in place and exits succesfully |
 | keygenJob.wireguardMgrImage | object | `{"pullPolicy":"Always","repository":"ghcr.io/bryopsida/k8s-wireguard-mgr","tag":"main"}` | When useWireguardManager is enabled this image is used instead of the kubectl image |
 | labels | object | `{}` |  |
 | metrics.dashboard.annotations | object | `{}` | Grafana dashboard annotations |

--- a/helm/wireguard/README.md
+++ b/helm/wireguard/README.md
@@ -79,7 +79,7 @@ A Helm chart for managing a wireguard vpn in kubernetes
 | keygenJob.resources.requests.cpu | string | `"100m"` |  |
 | keygenJob.resources.requests.ephemeral-storage | string | `"8Mi"` |  |
 | keygenJob.resources.requests.memory | string | `"256Mi"` |  |
-| keygenJob.useWireguardManager | bool | `true` | when enabled, uses a image with go bindings for k8s and wg    to create the secret if it does not exist, on re-runs it     leaves the existing secret in place and exits succesfully |
+| keygenJob.useWireguardManager | bool | `true` | when enabled, uses a image with go bindings for k8s and wg to create the secret if it does not exist, on re-runs it leaves the existing secret in place and exits succesfully |
 | keygenJob.wireguardMgrImage | object | `{"pullPolicy":"Always","repository":"ghcr.io/bryopsida/k8s-wireguard-mgr","tag":"main"}` | When useWireguardManager is enabled this image is used instead of the kubectl image |
 | labels | object | `{}` |  |
 | metrics.dashboard.annotations | object | `{}` | Grafana dashboard annotations |

--- a/helm/wireguard/values.yaml
+++ b/helm/wireguard/values.yaml
@@ -22,7 +22,7 @@ keygenJob:
   # -- when enabled, uses a image with go bindings for k8s and wg
   #    to create the secret if it does not exist, on re-runs it
   #    it leaves the existing secret in place and exits succesfully
-  useWireguardManager: false
+  useWireguardManager: true
   # -- When useWireguardManager is enabled this image is used instead of the kubectl image
   wireguardMgrImage:
     repository: ghcr.io/bryopsida/k8s-wireguard-mgr

--- a/helm/wireguard/values.yaml
+++ b/helm/wireguard/values.yaml
@@ -19,9 +19,7 @@ initContainer:
       cpu: "100m"
       ephemeral-storage: 64Mi
 keygenJob:
-  # -- when enabled, uses a image with go bindings for k8s and wg
-  #    to create the secret if it does not exist, on re-runs it 
-  #    leaves the existing secret in place and exits succesfully
+  # -- when enabled, uses a image with go bindings for k8s and wg to create the secret if it does not exist, on re-runs it leaves the existing secret in place and exits succesfully
   useWireguardManager: true
   # -- When useWireguardManager is enabled this image is used instead of the kubectl image
   wireguardMgrImage:

--- a/helm/wireguard/values.yaml
+++ b/helm/wireguard/values.yaml
@@ -20,8 +20,8 @@ initContainer:
       ephemeral-storage: 64Mi
 keygenJob:
   # -- when enabled, uses a image with go bindings for k8s and wg
-  #    to create the secret if it does not exist, on re-runs it
-  #    it leaves the existing secret in place and exits succesfully
+  #    to create the secret if it does not exist, on re-runs it 
+  #    leaves the existing secret in place and exits succesfully
   useWireguardManager: true
   # -- When useWireguardManager is enabled this image is used instead of the kubectl image
   wireguardMgrImage:


### PR DESCRIPTION
What
---
This enables using the wireguard keygen job to generate the wireguard secret, this handles the error case of the secret already existing gracefully.

I'm going to leave this open for a awhile to give people a chance to object to the change in default behavior.

Relates to #72 #46 