### PR TITLE
Remove duplicate "-s" in PostDown

### DIFF
--- a/helm/wireguard/Chart.yaml
+++ b/helm/wireguard/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wireguard
 description: A Helm chart for managing a wireguard vpn in kubernetes
 type: application
-version: 0.31.1
+version: 0.31.2
 appVersion: "0.0.0"
 maintainers:
   - name: bryopsida

--- a/helm/wireguard/README.md
+++ b/helm/wireguard/README.md
@@ -1,6 +1,6 @@
 # wireguard
 
-![Version: 0.31.1](https://img.shields.io/badge/Version-0.31.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
+![Version: 0.31.2](https://img.shields.io/badge/Version-0.31.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
 
 A Helm chart for managing a wireguard vpn in kubernetes
 

--- a/helm/wireguard/templates/config.yaml
+++ b/helm/wireguard/templates/config.yaml
@@ -4,7 +4,7 @@
 Address = {{ .Values.wireguard.serverAddress }}
 ListenPort = 51820
 PostUp = wg set wg0 private-key /etc/wireguard/privatekey && iptables -t nat -A POSTROUTING {{ $natSourceNetOption }} -o eth0 -j MASQUERADE
-PostDown = iptables -t nat -D POSTROUTING -s {{ $natSourceNetOption }} -o eth0 -j MASQUERADE
+PostDown = iptables -t nat -D POSTROUTING {{ $natSourceNetOption }} -o eth0 -j MASQUERADE
 {{- range $key, $value := .Values.wireguard.interfaceOpts }}
 {{ $key }} = {{ $value }}
 {{- end }}


### PR DESCRIPTION
The default PostDown is never executed successfully because there are 2 consecutive "-s".
When running in host network mode this means that the iptables rules are not deleted.