### PR TITLE
Configuration of affinity,nodeSelector,tolerations for keygenJob Pod

### DIFF
--- a/helm/wireguard/Chart.yaml
+++ b/helm/wireguard/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wireguard
 description: A Helm chart for managing a wireguard vpn in kubernetes
 type: application
-version: 0.31.2
+version: 0.32.0
 appVersion: "0.0.0"
 maintainers:
   - name: bryopsida

--- a/helm/wireguard/README.md
+++ b/helm/wireguard/README.md
@@ -1,6 +1,6 @@
 # wireguard
 
-![Version: 0.31.2](https://img.shields.io/badge/Version-0.31.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
+![Version: 0.32.0](https://img.shields.io/badge/Version-0.32.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
 
 A Helm chart for managing a wireguard vpn in kubernetes
 
@@ -57,6 +57,7 @@ A Helm chart for managing a wireguard vpn in kubernetes
 | initContainer.resources.requests.cpu | string | `"100m"` |  |
 | initContainer.resources.requests.ephemeral-storage | string | `"8Mi"` |  |
 | initContainer.resources.requests.memory | string | `"64Mi"` |  |
+| keygenJob.affinity | object | `{}` | Set keygenJob pod affinity or antiAffinity |
 | keygenJob.command | list | `["/job/entry-point.sh"]` | Specify the script to run to generate the private key |
 | keygenJob.containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
 | keygenJob.containerSecurityContext.privileged | bool | `false` |  |
@@ -69,6 +70,7 @@ A Helm chart for managing a wireguard vpn in kubernetes
 | keygenJob.image.pullPolicy | string | `"Always"` |  |
 | keygenJob.image.repository | string | `"ghcr.io/curium-rocks/wg-kubectl"` |  |
 | keygenJob.image.tag | string | `"latest"` |  |
+| keygenJob.nodeSelector | object | `{}` | Set keygenJob nodeSelector, a simplified version of affinity |
 | keygenJob.podAnnotations | object | `{}` |  |
 | keygenJob.podSecurityContext.fsGroup | int | `1000` |  |
 | keygenJob.podSecurityContext.fsGroupChangePolicy | string | `"Always"` |  |
@@ -79,6 +81,7 @@ A Helm chart for managing a wireguard vpn in kubernetes
 | keygenJob.resources.requests.cpu | string | `"100m"` |  |
 | keygenJob.resources.requests.ephemeral-storage | string | `"8Mi"` |  |
 | keygenJob.resources.requests.memory | string | `"256Mi"` |  |
+| keygenJob.tolerations | list | `[]` | Set keygenJob tolerations |
 | keygenJob.useWireguardManager | bool | `true` | when enabled, uses a image with go bindings for k8s and wg to create the secret if it does not exist, on re-runs it leaves the existing secret in place and exits succesfully |
 | keygenJob.wireguardMgrImage | object | `{"pullPolicy":"Always","repository":"ghcr.io/bryopsida/k8s-wireguard-mgr","tag":"main"}` | When useWireguardManager is enabled this image is used instead of the kubectl image |
 | labels | object | `{}` |  |

--- a/helm/wireguard/templates/privatekey-gen-job.yaml
+++ b/helm/wireguard/templates/privatekey-gen-job.yaml
@@ -112,6 +112,17 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.keygenJob.affinity }}
+      affinity:
+        {{- $affinity := .Values.keygenJob.affinity | toYaml }}
+        {{ tpl $affinity . | nindent 8 | trim }}
+      {{- end }}
+      {{- if .Values.keygenJob.nodeSelector }}
+      nodeSelector: {{ .Values.keygenJob.nodeSelector | toYaml | nindent 8 }}
+      {{- end }}
+      {{- if .Values.keygenJob.tolerations }}
+      tolerations: {{ .Values.keygenJob.tolerations | toYaml | nindent 8 }}
+      {{- end }}
       volumes:
         - name: script
           configMap:

--- a/helm/wireguard/values.yaml
+++ b/helm/wireguard/values.yaml
@@ -58,6 +58,21 @@ keygenJob:
   extraScripts: {}
   # -- Add additional environment variables to the key generation job, supports helm templating
   extraEnv: {}
+  # -- Set keygenJob pod affinity or antiAffinity
+  affinity: {}
+    # nodeAffinity:
+    #   requiredDuringSchedulingIgnoredDuringExecution:
+    #     nodeSelectorTerms:
+    #     - matchExpressions:
+    #       - key: "example.com/vpn"
+    #         operator: Exists
+  # -- Set keygenJob nodeSelector, a simplified version of affinity
+  nodeSelector: {}
+    # example.com/vpn: ""
+  # -- Set keygenJob tolerations
+  tolerations: []
+    # - effect: NoSchedule
+    #   operator: Exists
 podAnnotations: {}
 labels: {}
 # -- Run pod on host network


### PR DESCRIPTION
This PR makes it possiblet to configure the affinity, nodeSelector and tolerations  of the Pod that is creatred by the keyGen Job.
Use case:
Some of our Kubernetes clusters have no "free for all" nodes so the Pod can not be started anywhere - we need to add tolerations to it.